### PR TITLE
Removing the outline from arrows

### DIFF
--- a/css/flickity.css
+++ b/css/flickity.css
@@ -39,6 +39,7 @@
   background: white;
   background: hsla(0, 0%, 100%, 0.75);
   cursor: pointer;
+  outline: 0;
   /* vertically center */
   -webkit-transform: translateY(-50%);
       -ms-transform: translateY(-50%);


### PR DESCRIPTION
When any of the arrow is clicked, automatically is added an outline around it. This ends up not pleasing many developers...