### PR TITLE
fix overflow in getAdjacentCellElements

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -549,8 +549,11 @@ Flickity.prototype.getAdjacentCellElements = function( adjCount, index ) {
     return [ this.selectedElement ];
   }
   index = index === undefined ? this.selectedIndex : index;
-  var cellElems = [];
+
   var len = this.cells.length;
+  if ( 1 + ( adjCount * 2 ) >= len ) return this.getCellElements();
+
+  var cellElems = [];
   for ( var i = index - adjCount; i <= index + adjCount ; i++ ) {
     var cellIndex = this.options.wrapAround ? utils.modulo( i, len ) : i;
     var cell = this.cells[ cellIndex ];


### PR DESCRIPTION
If more cells are requested than exist, just return all of them.

This also fixes an issue in lazy-loading wherein the user needs to load more than ended up existing. Presently the image wouldn't load for the overflowed cells.