### PR TITLE
[LazyLoad] Background image lazy loading if attribute isn't an <img> tag

### DIFF
--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -65,12 +65,14 @@ Flickity.prototype.lazyLoad = function() {
 
 function getCellLazyImages( cellElem ) {
   // check if cell element is lazy image
-  if ( cellElem.nodeName == 'IMG' &&
-    cellElem.getAttribute('data-flickity-lazyload') ) {
+  if ( cellElem.getAttribute('data-flickity-lazyload') ) {
     return [ cellElem ];
   }
+
   // select lazy images in cell
-  var imgs = cellElem.querySelectorAll('img[data-flickity-lazyload]');
+  var imgs = cellElem.querySelectorAll('img[data-flickity-lazyload]')
+    || cellElem.querySelectorAll('[data-flickity-lazyload]');
+
   return utils.makeArray( imgs );
 }
 
@@ -90,8 +92,16 @@ LazyLoader.prototype.handleEvent = utils.handleEvent;
 LazyLoader.prototype.load = function() {
   eventie.bind( this.img, 'load', this );
   eventie.bind( this.img, 'error', this );
+
   // load image
-  this.img.src = this.img.getAttribute('data-flickity-lazyload');
+  var imgSrc = this.img.getAttribute('data-flickity-lazyload');
+
+  if(this.img.nodeName == 'IMG') {
+    this.img.src = imgSrc;
+  } else {
+    this.img.style.backgroundImage = 'url("' + imgsrc + '")';
+  }
+
   // remove attr
   this.img.removeAttribute('data-flickity-lazyload');
 };

--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -70,8 +70,7 @@ function getCellLazyImages( cellElem ) {
   }
 
   // select lazy images in cell
-  var imgs = cellElem.querySelectorAll('img[data-flickity-lazyload]')
-    || cellElem.querySelectorAll('[data-flickity-lazyload]');
+  var imgs = cellElem.querySelectorAll('[data-flickity-lazyload]');
 
   return utils.makeArray( imgs );
 }
@@ -99,7 +98,7 @@ LazyLoader.prototype.load = function() {
   if(this.img.nodeName == 'IMG') {
     this.img.src = imgSrc;
   } else {
-    this.img.style.backgroundImage = 'url("' + imgsrc + '")';
+    this.img.style.backgroundImage = 'url("' + imgSrc + '")';
   }
 
   // remove attr


### PR DESCRIPTION
as discussed in issue #173 - Lazy loading background images if the element isn't an image; It will append a background-image style allowing background-size: cover; and all that good CSS stuff to be done. 

As mentioned if the element nodename != IMG it will add background-image, this allows you to use it on divs, articles, sections, whatever you please.

Not too sure if I need to run gulp and compile the /dist/ stuff?