### PR TITLE
[RFR] Added `keyLeft` and `keyRight` events to `onkeydown` function

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -660,13 +660,13 @@ Flickity.prototype.onkeydown = function( event ) {
     // go left
     var leftMethod = this.options.rightToLeft ? 'next' : 'previous';
     this.uiChange();
-    this.dispatchEvent( 'keyLeft' );
+    this.dispatchEvent( 'keyLeft', event );
     this[ leftMethod ]();
   } else if ( event.keyCode == 39 ) {
     // go right
     var rightMethod = this.options.rightToLeft ? 'previous' : 'next';
     this.uiChange();
-    this.dispatchEvent( 'keyRight' );
+    this.dispatchEvent( 'keyRight', event );
     this[ rightMethod ]();
   }
 };

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -660,11 +660,13 @@ Flickity.prototype.onkeydown = function( event ) {
     // go left
     var leftMethod = this.options.rightToLeft ? 'next' : 'previous';
     this.uiChange();
+    this.dispatchEvent( 'keyLeft' );
     this[ leftMethod ]();
   } else if ( event.keyCode == 39 ) {
     // go right
     var rightMethod = this.options.rightToLeft ? 'previous' : 'next';
     this.uiChange();
+    this.dispatchEvent( 'keyRight' );
     this[ rightMethod ]();
   }
 };


### PR DESCRIPTION
This improvement was actually initiated by @smartmike —all credits to him— while we were working on an event dispatcher wrapping the Flickity one on a project of ours. 

Mike and I were surprised to see that Flickity actually does not fire any event when browsing through a gallery with keyboard rather than dragging / clicking. Still, it does fire events when clicking (`pointerUp` and `pointerDown`).

Are you interested in making this change? If you are, are the syntax and naming okay? If we can do anything, please be sure to ask. :)

By the way, thank you so much for Flickity. One of the best JS libraries we have ever worked with, and by far the best library for galleries. Amazing job. :)