### PR TITLE
Fix error event so for firefox

### DIFF
--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -100,7 +100,7 @@ LazyLoader.prototype.onload = function( event ) {
   this.complete( event, 'flickity-lazyloaded' );
 };
 
-LazyLoader.prototype.onerror = function() {
+LazyLoader.prototype.onerror = function( event ) {
   this.complete( event, 'flickity-lazyerror' );
 };
 


### PR DESCRIPTION
This error only fires on firefox, and when it does it logs a console
error (because ‘event’ is not declared).

Also, note that load event is notoriously unreliable for images (Chrome
will not fire it if the image is loaded from cache).  Stay tuned next
for more reliable version of this code that will always fire the
complete.   For now this fixes the console error message in FF.

Here's the CodePen that shows the fix working: http://s.codepen.io/stevemayhew/debug/dYYKvV
