### PR TITLE
slider drag stops working if index variable passed is not of type int…

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -432,6 +432,9 @@ Flickity.prototype.select = function( index, isWrap ) {
   if ( !this.isActive ) {
     return;
   }
+  // make sure index type is integer
+  index = parseInt(index);
+  
   // wrap position so slider is within normal area
   var len = this.cells.length;
   if ( this.options.wrapAround && len > 1 ) {


### PR DESCRIPTION
…eger

To avoid this case (and save people running into it a lot of time :)) I propose to just call parseInt on the passed parameter.

example: http://codepen.io/anon/pen/NGjgqR