### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ npm: `npm install flickity --save`
 
 ## License
 
-### Commerical license
+### Commercial license
 
-If you want to use Flickity to develop commercial sites, themes, projects, and applications, the Commercial license is the appropriate license. With this option, your source code is kept proprietary. Purchase a Flickity Commercial License at [flickity.metafizzy.co](http://flickity.metafizzy.co/#commerical-license)
+If you want to use Flickity to develop commercial sites, themes, projects, and applications, the Commercial license is the appropriate license. With this option, your source code is kept proprietary. Purchase a Flickity Commercial License at [flickity.metafizzy.co](http://flickity.metafizzy.co/#commercial-license)
 
 ### Open source license
 


### PR DESCRIPTION
@metafizzy, I've corrected a typographical error in the documentation of the [flickity](https://github.com/metafizzy/flickity) project. Specifically, I've changed commerical to commercial. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.