### PR TITLE
Use dynamically created element for supportsConditionalCSS test

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -621,15 +621,20 @@ var supportsConditionalCSS = Flickity.supportsConditionalCSS = ( function() {
       supports = false;
       return;
     }
-    // style body's :after and check that
+    // create a test element and check its :after
     var style = document.createElement('style');
-    var cssText = document.createTextNode('body:after { content: "foo"; display: none; }');
+    var cssText = document.createTextNode('#flickity-test:after { content: "foo"; display: none; }');
+    var element = document.createElement('div');
+    var afterContent;
+    element.id = 'flickity-test';
     style.appendChild( cssText );
     document.head.appendChild( style );
-    var afterContent = getComputedStyle( document.body, ':after' ).content;
+    document.body.appendChild( element );
+    afterContent = getComputedStyle( element, ':after' ).content;
     // check if able to get :after content
     supports = afterContent.indexOf('foo') != -1;
     document.head.removeChild( style );
+    document.body.removeChild( element );
     return supports;
   };
 })();


### PR DESCRIPTION
I came across an issue with flickity and the `watchCSS` option today.

The website I build has a styled `body:after` element. This causes the `supportsConditionalCSS()` test to fail on Safari (for some reason not in Chrome). 

I now moved the `body`s `:after` styles to `:before` and added a comment for future me. But to prevent this issue from happening to other people, please consider this pull request.

Awesome plugin by the way, I use it a lot these days.