### PR TITLE
Accessibility via aria hidden on cells.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,14 +146,14 @@ gulp.task( 'uglify', [ 'requirejs' ], function() {
 
 // ----- css ----- //
 
-var minifyCSS = require('gulp-minify-css');
+var cleanCSS = require('gulp-clean-css');
 
 gulp.task( 'css', function() {
   gulp.src('css/flickity.css')
     // copy to dist
     .pipe( gulp.dest('dist') )
     // minify
-    .pipe( minifyCSS({ advanced: false }) )
+    .pipe( cleanCSS({ advanced: false }) )
     .pipe( rename('flickity.min.css') )
     .pipe( replace( '*/', '*/\n' ) )
     .pipe( gulp.dest('dist') );

--- a/js/cell.js
+++ b/js/cell.js
@@ -48,7 +48,7 @@ Cell.prototype.create = function() {
   // default each cell to aria hidden
   // determination of selected cell
   // will change this state
-  this.element.setAttribute('aria-hidden', true);
+  this.element.setAriaHidden( true );
 };
 
 Cell.prototype.destroy = function() {
@@ -68,7 +68,7 @@ Cell.prototype.setPosition = function( x ) {
   this.renderPosition( x );
 };
 
-Cell.prototype.setAriaHidden = function ( val ) {
+Cell.prototype.setAriaHidden = function( val ) {
   this.element.setAttribute('aria-hidden', val);
 };
 

--- a/js/cell.js
+++ b/js/cell.js
@@ -48,7 +48,7 @@ Cell.prototype.create = function() {
   // default each cell to aria hidden
   // determination of selected cell
   // will change this state
-  this.element.setAriaHidden( true );
+  this.setAriaHidden( true );
 };
 
 Cell.prototype.destroy = function() {

--- a/js/cell.js
+++ b/js/cell.js
@@ -45,6 +45,10 @@ Cell.prototype.create = function() {
   }
   this.x = 0;
   this.shift = 0;
+  // default each cell to aria hidden
+  // determination of selected cell
+  // will change this state
+  this.element.setAttribute('aria-hidden', true);
 };
 
 Cell.prototype.destroy = function() {
@@ -62,6 +66,10 @@ Cell.prototype.setPosition = function( x ) {
   this.x = x;
   this.setDefaultTarget();
   this.renderPosition( x );
+};
+
+Cell.prototype.setAriaHidden = function ( val ) {
+  this.element.setAttribute('aria-hidden', val);
 };
 
 Cell.prototype.setDefaultTarget = function() {

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -477,11 +477,19 @@ Flickity.prototype.setSelectedCell = function() {
   this._removeSelectedCellClass();
   this.selectedCell = this.cells[ this.selectedIndex ];
   this.selectedElement = this.selectedCell.element;
+  // set aria hidden to false now that
+  // the cell is selected and then add
+  // the is-selected class
+  this.selectedCell.setAriaHidden( false );
   classie.add( this.selectedElement, 'is-selected' );
 };
 
 Flickity.prototype._removeSelectedCellClass = function() {
   if ( this.selectedCell ) {
+    // set aria hidden to true now that
+    // the previously selected cell is
+    // no longer selected
+    this.selectedCell.setAriaHidden( true );
     classie.remove( this.selectedCell.element, 'is-selected' );
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-replace": "^0.5.1",
     "gulp-uglify": "^1.0.2",
     "gulp-json-lint": "0.0.1",
-    "gulp-minify-css": "^0.4.5",
+    "gulp-clean-css": "^2.0.4",
     "minimist": "^1.1.0"
   },
   "scripts": {

--- a/sandbox/basic.html
+++ b/sandbox/basic.html
@@ -43,13 +43,13 @@
   <h1>basic1</h1>
 
   <div id="full-width" class="container">
-    <div class="cell" n1></div>
-    <div class="cell" n2></div>
-    <div class="cell" n3></div>
-    <div class="cell" n4></div>
-    <div class="cell" n5></div>
-    <div class="cell" n6></div>
-    <div class="cell" n7></div>
+    <div class="cell n1"></div>
+    <div class="cell n2"></div>
+    <div class="cell n3"></div>
+    <div class="cell n4"></div>
+    <div class="cell n5"></div>
+    <div class="cell n6"></div>
+    <div class="cell n7"></div>
   </div>
 
   <div id="half-width" class="container">


### PR DESCRIPTION
Upon instantiation each cell should now have `aria-hidden` set to true. When Flickity is activated and a cell is selected via `setSelectedCell` the `aria-hidden` attribute will be toggled to false. Upon cell change the `aria-hidden` attribute will be toggled to true.

I've also moved the n* classes in `sandbox/basic.html` into the class attribute as I believe that is where they should have been.

Finally I swapped out `gulp-minify-css` with `gulp-clean-css` because it's deprecated.

Hope this helps, this is really the first time I've contributed to anything so if I'm way off feel free to let me know. Would love to learn more and help out where I can. 