### PR TITLE
using gulp-clean-css, gulp-minify-css is deprecated

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,14 +146,14 @@ gulp.task( 'uglify', [ 'requirejs' ], function() {
 
 // ----- css ----- //
 
-var minifyCSS = require('gulp-minify-css');
+var cleanCSS = require('gulp-minify-css');
 
 gulp.task( 'css', function() {
   gulp.src('css/flickity.css')
     // copy to dist
     .pipe( gulp.dest('dist') )
     // minify
-    .pipe( minifyCSS({ advanced: false }) )
+    .pipe( cleanCSS({ advanced: false }) )
     .pipe( rename('flickity.min.css') )
     .pipe( replace( '*/', '*/\n' ) )
     .pipe( gulp.dest('dist') );

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-replace": "^0.5.1",
     "gulp-uglify": "^1.0.2",
     "gulp-json-lint": "0.0.1",
-    "gulp-minify-css": "^0.4.5",
+    "gulp-clean-css": "^2.0.4",
     "minimist": "^1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
[gulp-minify-css deprecation notice](https://www.npmjs.com/package/gulp-minify-css).