### PR TITLE
A patch to intergrate Flickity with React

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -237,6 +237,8 @@ Flickity.prototype._filterFindCellElements = function( elems ) {
 // goes through all children
 Flickity.prototype.reloadCells = function() {
   // collection of item elements
+  this.afterShiftCells=[];
+  this.beforeShiftCells=[];
   this.cells = this._makeCells( this.slider.children );
   this.positionCells();
   this._getWrapShiftCells();

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -105,7 +105,8 @@ Flickity.defaults = {
   selectedAttraction: 0.025,
   setGallerySize: true
   // watchCSS: false,
-  // wrapAround: false
+  // wrapAround: false,
+  // noDomMod: false
 };
 
 // hash of methods triggered on _create()
@@ -129,8 +130,16 @@ Flickity.prototype._create = function() {
   this.accel = 0;
   this.originSide = this.options.rightToLeft ? 'right' : 'left';
   // create viewport & slider
-  this.viewport = document.createElement('div');
-  this.viewport.className = 'flickity-viewport';
+  if (this.options.noDomMod) {
+    this.viewport = document.querySelector('.flickity-viewport');
+    if ( !this.viewport && console ) {
+      console.error( 'Could not find ".flickity-viewport"' );
+      return
+    }
+  } else {
+    this.viewport = document.createElement('div');
+    this.viewport.className = 'flickity-viewport';
+  }
   Flickity.setUnselectable( this.viewport );
   this._createSlider();
 
@@ -173,9 +182,11 @@ Flickity.prototype.activate = function() {
   this.getSize();
   // move initial cell elements so they can be loaded as cells
   var cellElems = this._filterFindCellElements( this.element.children );
-  moveElements( cellElems, this.slider );
-  this.viewport.appendChild( this.slider );
-  this.element.appendChild( this.viewport );
+  if (! this.options.noDomMod) {
+    moveElements( cellElems, this.slider );
+    this.viewport.appendChild( this.slider );
+    this.element.appendChild( this.viewport );
+  }
   // get cells from children
   this.reloadCells();
 
@@ -206,10 +217,17 @@ Flickity.prototype.activate = function() {
 // slider positions the cells
 Flickity.prototype._createSlider = function() {
   // slider element does all the positioning
-  var slider = document.createElement('div');
-  slider.className = 'flickity-slider';
-  slider.style[ this.originSide ] = 0;
-  this.slider = slider;
+  if (this.options.noDomMod) {
+    this.slider = document.querySelector('.flickity-slider');
+    if ( !this.slider && console ) {
+      console.error( 'Could not find ".flickity-slider"' );
+      return
+    }
+  } else {
+    this.slider = document.createElement('div');
+    this.slider.className = 'flickity-slider';
+  }
+  this.slider.style[ this.originSide ] = 0;
 };
 
 Flickity.prototype._filterFindCellElements = function( elems ) {
@@ -695,9 +713,9 @@ Flickity.prototype.deactivate = function() {
     cell.destroy();
   }
   this._removeSelectedCellClass();
-  this.element.removeChild( this.viewport );
+  this.options.noDomMod || this.element.removeChild( this.viewport );
   // move child elements back into element
-  moveElements( this.slider.children, this.element );
+  this.options.noDomMod || moveElements( this.slider.children, this.element );
   if ( this.options.accessibility ) {
     this.element.removeAttribute('tabIndex');
     eventie.unbind( this.element, 'keydown', this );


### PR DESCRIPTION
Hello. 
First of all, I have to admit, I'm not a js programmer. I have no knowledge of npm or whatever. So this is more a feature request than a pull request =)
Still, this pull request consists of two changes. 
The first one introduced 'noDomMod' option for Flickity. This option prevents DOM modifications inside Flickity. 
Why would anyone need this? When I used Flickity with React I realized, Flickity changes DOM and React fails (because React checks that DOM matches React's internal shadow DOM). The change Flickity made is trivial: only two div elements are added and cells are moved into them.
So the noDomMod patch is about basic react compatibility. In my case, I used react to filter out only matching tabs. But here is a simplier example, which just adds and removes cells:
http://codepen.io/anon/pen/VaJjmd  (sorry for a ton of JS, but this is how I'm using react...)

But there are several problems with this rendering. As you might notice, in the demo I'm using `.activate()` and `deactivate()` while I would prefer `.reloadCells()`.  First of all, reload doesn't update dots. And I didn't work around this issue. Secondly, reload mess with cells if I don't reset before and after wrap arrays. And this is the second commit: normalize wrapping behaviour on external DOM management.

So, basically, could anyone please review this and propose a `reloadCells` better patch?
(I read the contributing guideline, and lets agree, this is a mit licensed pull request)