### PR TITLE
incorrect usage of `this.on`

### DIFF
--- a/js/prev-next-button.js
+++ b/js/prev-next-button.js
@@ -71,7 +71,7 @@ PrevNextButton.prototype._create = function() {
   // tap
   this.on( 'tap', this.onTap );
   // pointerDown
-  this.on( 'pointerDown', function onPointerDown( button, event ) {
+  this.on( 'pointerDown', function onPointerDown( event ) {
     this.parent.childUIPointerDown( event );
   }.bind( this ));
 };


### PR DESCRIPTION
After seeing a type error on mobile devices, it appears that `this.on`'s first parameter is the actual event. This was causing a type error where the `event` further in the stack doesn't have `.preventDefault` because it's actually not an event.