### PR TITLE
reset normalized RWD default value for max-width on slider-images

### DIFF
--- a/css/flickity.css
+++ b/css/flickity.css
@@ -20,6 +20,10 @@ http://flickity.metafizzy.co
   height: 100%;
 }
 
+.flickity-slider img {
+  max-width: initial; /* reset normalized RWD's default of 100% */
+}
+
 /* draggable */
 
 .flickity-enabled.is-draggable {


### PR DESCRIPTION
Setting `max-width: 100%` on all images has been the default since RWD took off, like can be found in normalize.css for example. So much a habit one can easily forget to reset this value for images with a carousel, (_doing this PR will hopefully remind me next time to do so, and save me some time then_;)

```css
.flickity-slider img {
   max-width: initial;
}
```

Love this carousel BTW.

