### PR TITLE
do not use focus in ie to prevent jumping, use setActive instead.

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -823,10 +823,15 @@ Flickity.keyboardHandlers = {
 
 proto.focus = function() {
   var prevScrollY = window.pageYOffset;
-  this.element.focus();
-  // hack to fix scroll jump after focus, #76
-  if ( window.pageYOffset != prevScrollY ) {
-    window.scrollTo( window.pageXOffset, prevScrollY );
+  // Workaround for IE11
+  if (this.element.setActive) {
+      this.element.setActive();
+  } else {
+      this.element.focus();
+      // hack to fix scroll jump after focus, #76
+      if ( window.pageYOffset != prevScrollY ) {
+          window.scrollTo( window.pageXOffset, prevScrollY );
+      }
   }
 };
 


### PR DESCRIPTION
this updates the document.activeElement without focusing

see #651 