### PR TITLE
Take into account all elements when reload

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -226,7 +226,7 @@ proto._filterFindCellElements = function( elems ) {
 // goes through all children
 proto.reloadCells = function() {
   // collection of item elements
-  this.cells = this._makeCells( this.slider.children );
+  this.cells = this._makeCells( this.element.children );
   this.positionCells();
   this._getWrapShiftCells();
   this.setGallerySize();

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -226,7 +226,7 @@ proto._filterFindCellElements = function( elems ) {
 // goes through all children
 proto.reloadCells = function() {
   // collection of item elements
-  this.cells = this._makeCells( this.element.children );
+  this.cells = this._makeCells( this.options.cellSelector ? this.element.children : this.slider.children );
   this.positionCells();
   this._getWrapShiftCells();
   this.setGallerySize();


### PR DESCRIPTION
Hi !

Flickity currently uses this.slider.elements when you call reloadCells, which is actually the already filtered items (if you are using cellSelector).

In my use case, I dynamically change the classes, and call reloadCells to recalculate which cells must be displayed or not, so it must always redo the work on the initial, unfiltered set of cells.