### PR TITLE
add 'box-sizing: border-box' declaration

### DIFF
--- a/css/flickity.css
+++ b/css/flickity.css
@@ -4,6 +4,13 @@ https://flickity.metafizzy.co
 
 .flickity-enabled {
   position: relative;
+  box-sizing: border-box;
+}
+
+.flickity-enabled *,
+.flickity-enabled *:before,
+.flickity-enabled *:after {
+  box-sizing: inherit;
 }
 
 .flickity-enabled:focus { outline: none; }


### PR DESCRIPTION
For sites that are using a different box model, this ensures the default styles of Flickity display correctly, specifically buttons. Because of the use of `inherit`, this can easily be overridden with a single `box-sizing` declaration for `.flickity-enabled`.