### PR TITLE
Replace aria-selected with aria-hidden

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -39,7 +39,7 @@ var proto = Cell.prototype;
 
 proto.create = function() {
   this.element.style.position = 'absolute';
-  this.element.setAttribute( 'aria-selected', 'false' );
+  this.element.setAttribute( 'aria-hidden', 'true' );
   this.x = 0;
   this.shift = 0;
 };
@@ -48,7 +48,7 @@ proto.destroy = function() {
   // reset style
   this.element.style.position = '';
   var side = this.parent.originSide;
-  this.element.removeAttribute('aria-selected');
+  this.element.removeAttribute( 'aria-hidden' );
   this.element.style[ side ] = '';
 };
 

--- a/js/slide.js
+++ b/js/slide.js
@@ -63,7 +63,7 @@ proto.changeSelected = function( isSelected ) {
   var classMethod = isSelected ? 'add' : 'remove';
   this.cells.forEach( function( cell ) {
     cell.element.classList[ classMethod ]('is-selected');
-    if ( isSelected) {
+    if ( isSelected ) {
       cell.element.removeAttribute( 'aria-hidden' );
     } else {
       cell.element.setAttribute( 'aria-hidden', 'true' );

--- a/js/slide.js
+++ b/js/slide.js
@@ -63,7 +63,11 @@ proto.changeSelected = function( isSelected ) {
   var classMethod = isSelected ? 'add' : 'remove';
   this.cells.forEach( function( cell ) {
     cell.element.classList[ classMethod ]('is-selected');
-    cell.element.setAttribute( 'aria-selected', isSelected.toString() );
+    if ( isSelected) {
+      cell.element.removeAttribute( 'aria-hidden' );
+    } else {
+      cell.element.setAttribute( 'aria-hidden', 'true' );
+    }
   });
 };
 


### PR DESCRIPTION
**Problem**
`[aria-*]` attributes do not match their roles for slides. Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes.

**Solution**
The `aria-selected` is not appropriate here. Both examples below use `aria-hidden` which is an available ARIA attribute for almost any element.
- https://www.w3.org/WAI/tutorials/carousels/working-example/
- http://accessibility.athena-ict.com/aria/examples/carousel.shtml