### PR TITLE
Prevent breaking flickity when using slash URLs

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -727,6 +727,8 @@ proto.queryCell = function( selector ) {
     return this.cells[ selector ];
   }
   if ( typeof selector == 'string' ) {
+    // prevent querySelector error
+    if(!selector.charAt(0).match(/[a-z]/i)) return this.cells[0];
     // use string as selector, get element
     selector = this.element.querySelector( selector );
   }


### PR DESCRIPTION
For example:
http://test.com/#/
http://test.com/#123

https://www.w3.org/TR/CSS21/syndata.html#characters