### PR TITLE
Fix: Dragging on iOS 9.3 / Safari, copy pageX, pageY in _pointerDownDefault()

### DIFF
--- a/js/drag.js
+++ b/js/drag.js
@@ -150,7 +150,17 @@ proto.pointerDown = function( event, pointer ) {
 // default pointerDown logic, used for staticClick
 proto._pointerDownDefault = function( event, pointer ) {
   // track start event position
-  this.pointerDownPointer = pointer;
+  // Fix dragging on iOS 9.3 / Safari. metafizzy/flickity#/779
+  // Safari overrides pageX and pageY therefore these values needs to be copied
+  if (this.pointerDownPointer) {
+    this.pointerDownPointer.pageX = pointer.pageX;
+    this.pointerDownPointer.pageY = pointer.pageY;
+  } else {
+    this.pointerDownPointer = {
+      pageX: pointer.pageX,
+      pageY: pointer.pageY,
+    };
+  }
   // bind move and end events
   this._bindPostStartEvents( event );
   this.dispatchEvent( 'pointerDown', event, [ pointer ] );


### PR DESCRIPTION
Hey,
I found today that dragging doesn't work anymore in one of my projects on iOS 9.3 / Safari.
Unfortunately based on analytics, some of my customers still use 9.3 therefore I try to support that browser.

### **tl;dr**

I found that on iOS 9.3 `pageX` and `pageY` are overridden therefore `moveVector` is always calculated as `{ x: 0, y: 0 }` and dragging doesn't work.

### **fix**

Copy values of `pageX`, `pageY`.

### **Very long explanation**

I found that the last version that works on iOS 9.3 is flickity `2.1.0` so 
[I checked the difference between `2.1.0` and `2.1.1`](https://github.com/metafizzy/flickity/compare/v2.1.0...v2.1.1):

![zrzut ekranu 2018-09-24 o 16 37 42](https://user-images.githubusercontent.com/1313605/45958615-340fd100-c018-11e8-83c6-3cc0f159d7a0.png)

I focused on `🛠 refactor pointerDown for Unidragger 2.3.` and after some long `console.logging`, I found that `moveVector` is always  calculated as `{ x: 0, y: 0}` so I started digging around this particular part of the code.

Also I checked [the difference between unidragger v2.2.3 and v2.3.0](https://github.com/metafizzy/unidragger/compare/v2.2.3...v2.3.0) and I found that `movePoint` was always calculated as a new object because `Unipointer.getPointerPoint` always returns a new object...

```js
// utility function for getting x/y coords from event
Unipointer.getPointerPoint = function( pointer ) {
  return {
    x: pointer.pageX,
    y: pointer.pageY
  };
};
``` 

**Diff unidragger v2.2.3 / v2.3.0**

```diff
// base pointer move logic
proto._dragPointerMove = function( event, pointer ) {
-  var movePoint = Unipointer.getPointerPoint( pointer );
  var moveVector = {
-    x: movePoint.x - this.pointerDownPoint.x,
-    y: movePoint.y - this.pointerDownPoint.y
+    x: pointer.pageX - this.pointerDownPointer.pageX,
+    y: pointer.pageY - this.pointerDownPointer.pageY
  };
```

Finally, I decided to copy `pageX`, `pageY` in `js/drag.jg` and it turned out that dragging works again on iOS 9.3.

----

To be honest I'm not so familiar with the whole codebase of flickity and it's hard to say for me why it works on desktop / iOS 10, and why on iOS 9.x somehow `this.pointerDownPointer.pageX` is mutated.

By the way, [the same concept of assigning `this.pointerDownPoint = pointer` is applied in unidragger](https://github.com/metafizzy/unidragger/compare/v2.2.3...v2.3.0#diff-bdf3066081d472b39cdd3d8bb82dc2d0R92) so maybe it should be also updated.

**Demo:** https://codepen.io/hinok/pen/rZgWjm

In codepen, please look for `@FIX` in the code section to find my changes.

### **Before fix (dragging doesn't work)**

<img width="1440" alt="ios 9 3 safari - before fix" src="https://user-images.githubusercontent.com/1313605/45961722-86a0bb80-c01f-11e8-8129-d6d12f7e11b0.png">

### **After fix (dragging works)**

<img width="1440" alt="ios 9 3 safari - after fix" src="https://user-images.githubusercontent.com/1313605/45961738-928c7d80-c01f-11e8-9d52-5d7c5098b9a4.png">


**Related:**
* https://github.com/metafizzy/flickity/issues/779

