### PR TITLE
Use currentColor for nav icon color

### DIFF
--- a/css/flickity.css
+++ b/css/flickity.css
@@ -73,7 +73,7 @@ https://flickity.metafizzy.co
 }
 
 .flickity-button-icon {
-  fill: #333;
+  fill: currentColor;
 }
 
 /* ---- previous/next buttons ---- */


### PR DESCRIPTION
I've been meaning to make a pull request for this for a while. I notice it was [discussed recently](https://github.com/metafizzy/flickity/pull/852).

Just a tiny change to allow changing the SVG icon fill colour via the current text colour using the `currentColor` keyword.