### PR TITLE
:sparkles: Add ability to localize the aria labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,17 @@ var flky = new Flickity( '.gallery', {
   // watches the content of :after of the element
   // activates if #element:after { content: 'flickity' }
 
-  wrapAround: false
+  wrapAround: false,
   // at end of cells, wraps-around to first for infinite scrolling
+
+  l18nPageDot: 'Page dot %'
+  // Aria label for the page dots. `%` gets replaced with the slide number
+
+  l18nPrevious: 'Previous',
+  // Aria label for the previous button
+
+  l18nNext: 'Next'
+   // Aria label for the next button
 
 });
 ```

--- a/js/page-dots.js
+++ b/js/page-dots.js
@@ -85,7 +85,7 @@ PageDots.prototype.addDots = function( count ) {
   for ( var i = length; i < max; i++ ) {
     var dot = document.createElement('li');
     dot.className = 'dot';
-    dot.setAttribute( 'aria-label', 'Page dot ' + ( i + 1 ) );
+    dot.setAttribute( 'aria-label', this.parent.options.l18nPageDot.replace('', i + 1) );
     fragment.appendChild( dot );
     newDots.push( dot );
   }
@@ -139,7 +139,8 @@ Flickity.PageDots = PageDots;
 // -------------------------- Flickity -------------------------- //
 
 utils.extend( Flickity.defaults, {
-  pageDots: true
+  pageDots: true,
+  l18nPageDot: 'Page dot %'
 });
 
 Flickity.createMethods.push('_createPageDots');

--- a/js/prev-next-button.js
+++ b/js/prev-next-button.js
@@ -59,7 +59,7 @@ PrevNextButton.prototype._create = function() {
   // init as disabled
   this.disable();
 
-  element.setAttribute( 'aria-label', this.isPrevious ? 'Previous' : 'Next' );
+  element.setAttribute('aria-label', this.parent.options[this.isPrevious ? 'l18nPrevious' : 'l18nNext']);
 
   // create arrow
   var svg = this.createSVG();
@@ -178,6 +178,8 @@ PrevNextButton.prototype.destroy = function() {
 
 utils.extend( Flickity.defaults, {
   prevNextButtons: true,
+  l18nPrevious: 'Previous',
+  l18nNext: 'Next',
   arrowShape: {
     x0: 10,
     x1: 60, y1: 50,


### PR DESCRIPTION
Unfortunately, all aria labels are hardcoded in English. This PR allows setting the label for page dots and the previous/next buttons.