### PR TITLE
Check for instance before setting options

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -76,7 +76,7 @@ function Flickity( element, options ) {
   // do not initialize twice on same element
   if ( this.element.flickityGUID ) {
     var instance = instances[ this.element.flickityGUID ];
-    instance.option( options );
+    instance && instance.option( options );
     return instance;
   }
 


### PR DESCRIPTION
We are encountering a problem when a page uses Flickity, but uses a plug-in/external library that has Flickity as well.

When it initializes Flickity the second time on elements with the `data-flickity` attribute, `this.element` will have a `flickityGUID` but `instances` will be empty, and so `instance` will be undefined and `instance.option` will throw an exception.

It looks like [this problem](https://github.com/metafizzy/flickity/issues/484) has been brought up in the past as a hypothetical, but we're now seeing it appear on a production website.

I have created [a reduced test case](https://codepen.io/rhys-developer/pen/oNvKZxa) which is simply the Basic CodePen example but with the Flickity package included twice in the External Scripts.

Thanks!