### PR TITLE
Changed rename in Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,7 @@ gulp.task( 'uglify', function() {
     .pipe( uglify() )
     // add banner
     .pipe( addBanner( banner ) )
-    .pipe( rename('flickity.pkgd.min.js') )
+    .pipe( rename({ suffix: '.min' }) )
     .pipe( gulp.dest('dist') );
 });
 
@@ -110,7 +110,7 @@ gulp.task( 'css', function() {
     .pipe( gulp.dest('dist') )
     // minify
     .pipe( cleanCSS({ advanced: false }) )
-    .pipe( rename('flickity.min.css') )
+    .pipe( rename({ suffix: '.min' }) )
     .pipe( replace( '*/', '*/\n' ) )
     .pipe( gulp.dest('dist') );
 });


### PR DESCRIPTION
The rename was changed to just use the `suffix` option in case you ever decide to change the source file names and wanted the renamed files to match.