### PR TITLE
Fix/stop autoplay on focus

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -140,6 +140,7 @@ proto.activatePlayer = function() {
   }
   this.player.play();
   this.element.addEventListener( 'mouseenter', this );
+  this.element.addEventListener( 'focus', this );
 };
 
 // Player API, don't hate the ... thanks I know where the door is
@@ -180,6 +181,17 @@ proto.onmouseenter = function() {
 proto.onmouseleave = function() {
   this.player.unpause();
   this.element.removeEventListener( 'mouseleave', this );
+};
+
+// ----- focus/blur ----- //
+proto.onfocus = function() {
+  this.player.pause();
+  this.element.addEventListener( 'blur', this );
+};
+
+proto.onblur = function() {
+  this.player.unpause();
+  this.element.removeEventListener( 'blur', this );
 };
 
 // -----  ----- //

--- a/js/prev-next-button.js
+++ b/js/prev-next-button.js
@@ -72,6 +72,8 @@ PrevNextButton.prototype._create = function() {
 PrevNextButton.prototype.activate = function() {
   this.bindStartEvent( this.element );
   this.element.addEventListener( 'click', this );
+  this.element.addEventListener( 'focus', this );
+  // console.log(this.parent.element);
   // add to DOM
   this.parent.element.appendChild( this.element );
 };
@@ -125,6 +127,22 @@ PrevNextButton.prototype.onclick = function() {
   this.parent.uiChange();
   var method = this.isPrevious ? 'previous' : 'next';
   this.parent[ method ]();
+};
+
+PrevNextButton.prototype.onfocus = function() {
+  if ( !this.isEnabled ) {
+    return;
+  }
+  this.parent.stopPlayer();
+  this.element.addEventListener( 'blur', this );
+};
+
+PrevNextButton.prototype.onblur = function() {
+  if ( !this.isEnabled ) {
+    return;
+  }
+  this.parent.playPlayer();
+  this.element.removeEventListener( 'blur', this );
 };
 
 // -----  ----- //

--- a/js/prev-next-button.js
+++ b/js/prev-next-button.js
@@ -73,7 +73,6 @@ PrevNextButton.prototype.activate = function() {
   this.bindStartEvent( this.element );
   this.element.addEventListener( 'click', this );
   this.element.addEventListener( 'focus', this );
-  // console.log(this.parent.element);
   // add to DOM
   this.parent.element.appendChild( this.element );
 };


### PR DESCRIPTION
A carousel set to `autoplay` does not stop when it is focused. This is an issue for screen reader and other keyboard users who can't prevent this via hovering with a mouse. See [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#carousel).

This PR stops the carousel when it has focus _or_ one of the buttons has focus and resumed autoplaying when these are blurred.