### PR TITLE
iOS 13 bugfix

### DIFF
--- a/js/drag.js
+++ b/js/drag.js
@@ -218,7 +218,6 @@ proto.dragMove = function( event, pointer, moveVector ) {
   }
   event.preventDefault();
 
-  this.previousDragX = this.dragX;
   // reverse if right-to-left
   var direction = this.options.rightToLeft ? -1 : 1;
   if ( this.options.wrapAround ) {
@@ -235,6 +234,10 @@ proto.dragMove = function( event, pointer, moveVector ) {
     dragX = dragX < endBound ? ( dragX + endBound ) * 0.5 : dragX;
   }
 
+  if (this.dragX !== dragX) {
+    this.previousDragX = this.dragX;
+  }
+  
   this.dragX = dragX;
 
   this.dragMoveTime = new Date();


### PR DESCRIPTION
It looks like dragMove and dragEnd are both called on dragEnd in iOS 13.
previousDragX and dragX become the same value because of the dragMove call.
dragEndBoostSelect when called, evaluates to zero.

This primitive solution only reassigns previousDragX when dragX is changing.

Fixes: #992 #959 