### PR TITLE
Create Flickity constructor with custom window reference (e.g for iframes)

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -67,6 +67,7 @@
 'use strict';
 
 // vars
+var document = window.document
 var jQuery = window.jQuery;
 var getComputedStyle = window.getComputedStyle;
 var console = window.console;

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -16,10 +16,10 @@
         return factory(window, EvEmitter, getSize, utils, Cell, Slide, animatePrototype);
       }
       
-      var instance = withWindow(window);
-      instance.withWindow = withWindow;
+      var constructor = withWindow(window);
+      constructor.withWindow = withWindow;
   
-      return instance;
+      return constructor;
     });
   } else if ( typeof module == 'object' && module.exports ) {
     function withWindow( window ) {
@@ -34,11 +34,11 @@
       );
     }
 
-    var instance = withWindow(window);
-    instance.withWindow = withWindow;
+    var constructor = withWindow(window);
+    constructor.withWindow = withWindow;
 
     // CommonJS
-    module.exports = instance;
+    module.exports = constructor;
   } else {
     function withWindow( window ) {
       // browser global
@@ -55,10 +55,10 @@
       );
     }
 
-    var instance = withWindow(window);
-    instance.withWindow = withWindow;
+    var constructor = withWindow(window);
+    constructor.withWindow = withWindow;
 
-    window.Flickity = instance;
+    window.Flickity = constructor;
   }
 
 }( window, function factory( window, EvEmitter, getSize,

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -12,32 +12,53 @@
       './slide',
       './animate'
     ], function( EvEmitter, getSize, utils, Cell, Slide, animatePrototype ) {
-      return factory( window, EvEmitter, getSize, utils, Cell, Slide, animatePrototype );
+      function withWindow( window ) {
+        return factory(window, EvEmitter, getSize, utils, Cell, Slide, animatePrototype);
+      }
+      
+      var instance = withWindow(window);
+      instance.withWindow = withWindow;
+  
+      return instance;
     });
   } else if ( typeof module == 'object' && module.exports ) {
-    // CommonJS
-    module.exports = factory(
-      window,
-      require('ev-emitter'),
-      require('get-size'),
-      require('fizzy-ui-utils'),
-      require('./cell'),
-      require('./slide'),
-      require('./animate')
-    );
-  } else {
-    // browser global
-    var _Flickity = window.Flickity;
+    function withWindow( window ) {
+      return factory(
+        window,
+        require('ev-emitter'),
+        require('get-size'),
+        require('fizzy-ui-utils'),
+        require('./cell'),
+        require('./slide'),
+        require('./animate')
+      );
+    }
 
-    window.Flickity = factory(
-      window,
-      window.EvEmitter,
-      window.getSize,
-      window.fizzyUIUtils,
-      _Flickity.Cell,
-      _Flickity.Slide,
-      _Flickity.animatePrototype
-    );
+    var instance = withWindow(window);
+    instance.withWindow = withWindow;
+
+    // CommonJS
+    module.exports = instance;
+  } else {
+    function withWindow( window ) {
+      // browser global
+      var _Flickity = window.Flickity;
+  
+      return factory(
+        window,
+        window.EvEmitter,
+        window.getSize,
+        window.fizzyUIUtils,
+        _Flickity.Cell,
+        _Flickity.Slide,
+        _Flickity.animatePrototype
+      );
+    }
+
+    var instance = withWindow(window);
+    instance.withWindow = withWindow;
+
+    window.Flickity = instance;
   }
 
 }( window, function factory( window, EvEmitter, getSize,


### PR DESCRIPTION
Flickity uses the `window` that the script initiates in. However, there are use cases where an iframe is used and HTML is dynamically injected into it to act like a "sandbox", isolating the iframe content from the parent `window`.

In such a case, Flickity may initiate on the parent `window`, but should reference the `window` and `document` of the iframe.

This pull request adds a very simple `withWindow` helper function to build a Flickity constructor with a specific `window` reference. This was the most minimally invasive way of achieving this goal.

Examples:

```es6
/*
 default module import
*/

import Flickity from 'flickity'

const iframe = document.createElement('iframe')
const CustomFlickity = Flickity.withWindow(iframe.contentWindow)

const carousel = new CustomFlickity( '.my-carousel', {} )

/*
 or - destructured module import
*/

import { withWindow } from 'flickity'

const Flickity = withWindow(iframe.contentWindow)
const carousel = new Flickity( '.my-carousel', {} )

/*
 or - commonjs require
*/

const Flickity = require('flickity').withWindow(iframe.contentWindow)
const carousel = new Flickity( '.my-carousel', {} )

/*
 or - browser
*/

const Flickity = window.Flickity.withWindow(iframe.contentWindow)
const carousel = new Flickity( '.my-carousel', {} )
```