### PR TITLE
docs: Fix simple typo, tranforms -> transforms

### DIFF
--- a/dist/flickity.pkgd.js
+++ b/dist/flickity.pkgd.js
@@ -1028,7 +1028,7 @@ proto.setTranslateX = function( x, is3d ) {
   // reverse if right-to-left and using transform
   x = this.options.rightToLeft ? -x : x;
   var translateX = this.getPositionValue( x );
-  // use 3D tranforms for hardware acceleration on iOS
+  // use 3D transforms for hardware acceleration on iOS
   // but use 2D when settled, for better font-rendering
   this.slider.style.transform = is3d ?
     'translate3d(' + translateX + ',0,0)' : 'translateX(' + translateX + ')';

--- a/js/animate.js
+++ b/js/animate.js
@@ -78,7 +78,7 @@ proto.setTranslateX = function( x, is3d ) {
   // reverse if right-to-left and using transform
   x = this.options.rightToLeft ? -x : x;
   var translateX = this.getPositionValue( x );
-  // use 3D tranforms for hardware acceleration on iOS
+  // use 3D transforms for hardware acceleration on iOS
   // but use 2D when settled, for better font-rendering
   this.slider.style.transform = is3d ?
     'translate3d(' + translateX + ',0,0)' : 'translateX(' + translateX + ')';


### PR DESCRIPTION
There is a small typo in dist/flickity.pkgd.js, js/animate.js.

Should read `transforms` rather than `tranforms`.

