### PR TITLE
Lazyload picture

### DIFF
--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -97,7 +97,7 @@ LazyLoader.prototype.load = function() {
     this.img.getAttribute('data-flickity-lazyload-src');
   var srcset = this.img.getAttribute('data-flickity-lazyload-srcset');
   // set src & serset
-  if ( src ) {
+  if ( this.img.tagName.toLowerCase() === 'img' && src ) {
     this.img.src = src;
   }
   if ( srcset ) {

--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -97,7 +97,9 @@ LazyLoader.prototype.load = function() {
     this.img.getAttribute('data-flickity-lazyload-src');
   var srcset = this.img.getAttribute('data-flickity-lazyload-srcset');
   // set src & serset
-  this.img.src = src;
+  if ( src ) {
+    this.img.src = src;
+  }
   if ( srcset ) {
     this.img.setAttribute( 'srcset', srcset );
   }

--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -68,7 +68,8 @@ function getCellLazyImages( cellElem ) {
   }
   // select lazy images in cell
   var lazySelector = 'img[data-flickity-lazyload], ' +
-    'img[data-flickity-lazyload-src], img[data-flickity-lazyload-srcset]';
+    'img[data-flickity-lazyload-src], img[data-flickity-lazyload-srcset], ' +
+    'source[data-flickity-lazyload-srcset]';
   var imgs = cellElem.querySelectorAll( lazySelector );
   return utils.makeArray( imgs );
 }

--- a/test/index.html
+++ b/test/index.html
@@ -55,6 +55,7 @@
   <script src="unit/destroy.js"></script>
   <script src="unit/lazyload.js"></script>
   <script src="unit/lazyload-srcset.js"></script>
+  <script src="unit/lazyload-picture-srcset.js"></script>
   <script src="unit/group-cells.js"></script>
   <script src="unit/adaptive-height.js"></script>
   <script src="unit/select-cell.js"></script>
@@ -233,6 +234,25 @@
         https://picsum.photos/360/270/?image=517 360w"
       sizes="(min-width: 1024px) 720px, 360px"
       />
+    <div class="cell"></div>
+    <div class="cell"></div>
+    <div class="cell"></div>
+    <div class="cell"></div>
+  </div>
+
+  <h2>lazyload picture source srcset</h2>
+  <div id="lazyload-picture-srcset" class="gallery">
+    <div class="cell">
+      <picture>
+        <source
+          data-flickity-lazyload-srcset="https://via.placeholder.com/800x600.png?text=Image+1+Large+1x 1x,
+          https://via.placeholder.com/1600x1200.png?text=Image+1+Large+2x 2x" media="(min-width: 800px)">
+        <source
+          data-flickity-lazyload-srcset="https://via.placeholder.com/320x200.png?text=Image+1+Small+1x 1x,
+            https://via.placeholder.com/640x400.png?text=LImage+1+arge+2x 2x" media="(max-width: 799px)">
+        <img data-flickity-lazyload-src="https://via.placeholder.com/800x600.png?text=Image+1+Fallback">
+      </picture>
+    </div>
     <div class="cell"></div>
     <div class="cell"></div>
     <div class="cell"></div>

--- a/test/index.html
+++ b/test/index.html
@@ -245,18 +245,14 @@
     <div class="cell">
       <picture>
         <source
-          data-flickity-lazyload-srcset="https://via.placeholder.com/800x600.png?text=Image+1+Large+1x 1x,
-          https://via.placeholder.com/1600x1200.png?text=Image+1+Large+2x 2x" media="(min-width: 800px)">
+          data-flickity-lazyload-srcset="https://via.placeholder.com/800x600.png?text=Large+1x 1x,
+          https://via.placeholder.com/1600x1200.png?text=Large+2x 2x" media="(min-width: 800px)">
         <source
-          data-flickity-lazyload-srcset="https://via.placeholder.com/320x200.png?text=Image+1+Small+1x 1x,
-            https://via.placeholder.com/640x400.png?text=LImage+1+arge+2x 2x" media="(max-width: 799px)">
+          data-flickity-lazyload-srcset="https://via.placeholder.com/320x200.png?text=Small+1x 1x,
+            https://via.placeholder.com/640x400.png?text=Small+2x 2x" media="(max-width: 799px)">
         <img data-flickity-lazyload-src="https://via.placeholder.com/800x600.png?text=Image+1+Fallback">
       </picture>
     </div>
-    <div class="cell"></div>
-    <div class="cell"></div>
-    <div class="cell"></div>
-    <div class="cell"></div>
   </div>
 
   <h2>groupCells</h2>

--- a/test/unit/lazyload-picture-srcset.js
+++ b/test/unit/lazyload-picture-srcset.js
@@ -1,0 +1,28 @@
+QUnit.test( 'lazyload picture srcset', function( assert ) {
+  'use strict';
+
+  var done = assert.async();
+
+  var gallery = document.querySelector('#lazyload-picture-srcset');
+  var flkty = new Flickity( gallery, {
+    lazyLoad: 1,
+  } );
+
+  var loadCount = 0;
+  flkty.on( 'lazyLoad', function( event, cellElem ) {
+    loadCount++;
+
+    assert.equal( event.type, 'load', 'event.type == load' );
+    assert.ok( event.target.complete, 'img ' + loadCount + ' is complete' );
+    assert.ok( cellElem, 'cellElement argument there' );
+    var srcset = event.target.getAttribute('srcset');
+    assert.ok( srcset, 'srcset attribute set' );
+    var lazyAttr = event.target.getAttribute('data-flickity-lazyload-srcset');
+    assert.ok( !lazyAttr, 'data-flickity-lazyload attribute removed' );
+
+    if ( loadCount == 2 ) {
+      done();
+    }
+  } );
+
+} );

--- a/test/unit/lazyload-picture-srcset.js
+++ b/test/unit/lazyload-picture-srcset.js
@@ -15,10 +15,12 @@ QUnit.test( 'lazyload picture srcset', function( assert ) {
     assert.equal( event.type, 'load', 'event.type == load' );
     assert.ok( event.target.complete, 'img ' + loadCount + ' is complete' );
     assert.ok( cellElem, 'cellElement argument there' );
-    var srcset = event.target.getAttribute('srcset');
-    assert.ok( srcset, 'srcset attribute set' );
-    var lazyAttr = event.target.getAttribute('data-flickity-lazyload-srcset');
-    assert.ok( !lazyAttr, 'data-flickity-lazyload attribute removed' );
+    var sources = cellElem.querySelectorAll('source[srcset]');
+    assert.equal( sources.length, 2, 'All source elements of cell loaded' );
+    var lazyAttr = Array.from( sources ).some( function( el ) {
+      return el.getAttribute('data-flickity-lazyload-srcset');
+    } );
+    assert.ok( !lazyAttr, 'data-flickity-lazyload-srcset attribute removed' );
 
     if ( loadCount == 2 ) {
       done();


### PR DESCRIPTION
This merge request adds a desired feature: Lazy loading for picture/source elements. 
This feature is important as <img> srcset attribute cannot handle pixel density and viewport width at the same time.