### PR TITLE
fix(animation): use transform translate over setting left/right

### DIFF
--- a/js/animate.js
+++ b/js/animate.js
@@ -106,10 +106,18 @@ proto.getPositionValue = function( position ) {
   if ( this.options.percentPosition ) {
     // percent position, round to 2 digits, like 12.34%
     return ( Math.round( ( position / this.size.innerWidth ) * 10000 ) * 0.01 ) + '%';
-  } else {
-    // pixel positioning
-    return Math.round( position ) + 'px';
   }
+  // pixel positioning
+  return Math.round( position ) + 'px';
+};
+
+proto.getInversePositionValue = function( position ) {
+  if ( this.options.percentPosition ) {
+    // percent position, round to 2 digits, like 12.34%
+    return -1 * (Math.round((position / this.size.innerWidth) * 10000) * 0.01) + '%';
+  }
+  // pixel positioning
+  return -1 * Math.round( position ) + 'px';
 };
 
 proto.settle = function( previousX ) {

--- a/js/cell.js
+++ b/js/cell.js
@@ -71,8 +71,11 @@ proto.updateTarget = proto.setDefaultTarget = function() {
 
 proto.renderPosition = function( x ) {
   // render position of cell with in slider
-  var side = this.parent.originSide;
-  this.element.style[ side ] = this.parent.getPositionValue( x );
+  var adjustmentValue = this.parent.originSide == 'left' ?
+    this.parent.getPositionValue( x ) :
+    this.parent.getInversePositionValue( x );
+
+  this.element.style.transform = 'translateX(' + adjustmentValue + ')';
 };
 
 proto.select = function() {


### PR DESCRIPTION
Resolves https://github.com/metafizzy/flickity/issues/1087 (WIP)

[As pointed out](https://github.com/metafizzy/flickity/issues/1087#issuecomment-798593389) on the issue, [adjusting `left` / `right` may cause layout shift](https://web.dev/cls/#animations-and-transitions).

This change replaces `left` and `right` manipulation with `transform: translateX()`, which removes the layout shift and therefore Cumulative Layout Shift (CLS) penalties when using options: `autoPlay: true` and `wrapAround: true`.