### PR TITLE
feat(renderPosition): use more efficient transforms when percentPosition is false

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -49,6 +49,7 @@ proto.destroy = function() {
   this.element.style.position = '';
   var side = this.parent.originSide;
   this.element.style[ side ] = '';
+  this.element.style.transform = '';
   this.element.removeAttribute('aria-hidden');
 };
 
@@ -72,7 +73,24 @@ proto.updateTarget = proto.setDefaultTarget = function() {
 proto.renderPosition = function( x ) {
   // render position of cell with in slider
   var side = this.parent.originSide;
-  this.element.style[ side ] = this.parent.getPositionValue( x );
+  var positionValue = this.parent.getPositionValue( x );
+  if ( this.parent.options.percentPosition ) {
+    this.element.style[ side ] = positionValue;
+  } else {
+    this.element.style[ side ] = 0;
+
+    // when not using `percentPosition` (which means left/right offset
+    // is now calculated in pixels) prefer using a transform
+    // based position, as transforms are more efficient and
+    // do not affect Cumulative Layout Shift
+    var newPosition = this.element.style.transform;
+    if (side === 'left') {
+      newPosition = `translateX(${positionValue})`;
+    } else {
+      newPosition = `translateX(calc(${positionValue} * -1))`;
+    }
+    this.element.style.transform = newPosition;
+  }
 };
 
 proto.select = function() {

--- a/sandbox/wrap-around.html
+++ b/sandbox/wrap-around.html
@@ -124,6 +124,16 @@
     <div class="cell n4">4</div>
   </div>
 
+  <h2>Minimized Cumulative Layout Shift</h2>
+  <div id="galleryNoCls" class="container variable-width">
+    <div class="cell n1">1</div>
+    <div class="cell n2 w2">2</div>
+    <div class="cell n3 w3">3</div>
+    <div class="cell n4">4</div>
+    <div class="cell n5 w2">5</div>
+    <div class="cell n6">6</div>
+  </div>
+
 <script src="../bower_components/get-size/get-size.js"></script>
 <script src="../bower_components/desandro-matches-selector/matches-selector.js"></script>
 <script src="../bower_components/ev-emitter/ev-emitter.js"></script>
@@ -165,6 +175,10 @@ window.onload = function() {
     freeScroll: true
   });
 
+  var flkyNoCLS = window.flky = new Flickity( '#galleryNoCls', {
+    wrapAround: true,
+    percentPosition: false
+  });
 
 
 };


### PR DESCRIPTION
Hello and thank you for the effort of maintaining this package, we have been using it for years and it has served us very well :)

This is PR in regards to this issue and particular comment: https://github.com/metafizzy/flickity/issues/1087#issuecomment-768598816

### Background
We have been resolving layout shift (CLS) issues on a website we support in preparation for the Google ranking changes coming up in May 2021. We noticed a ticker component - a carousel which auto-animates was raising our layout shift every time it moved. 
This was pinpointed to be horizontal layout shift due to the use of `left` and `right` to adjust the cell position in the carousel.

### Solution
My aim in this PR was to replace uses of `left`/`right` positioning with the appropriate `transform: translateX(value)`, which does not affect CLS.
I found, this would be quite complicated for carousels that use `percentPosition: true` but is a fairly simple task for those which use `percentPosition: false` (pixels) for their calculation.
Thus this PR provides a partial fix, only affecting carousels with the option of `percentPosition: false` but I still think an improvement to the current behaviour.

### Images of performance tests 
(via Chrome Performance tab); while scrolling through a `wrap-around` carousel

#### Before changes (or using `percentPosition: true`):
(Notice Red bars under `Experience` - these are all CLS occurrences)
![Screenshot 2021-03-15 at 13 04 23](https://user-images.githubusercontent.com/6905473/111157815-3b801780-858f-11eb-8d86-30a762e79f7c.png)


#### After changes (_and_ using `percentPosition: false`):
Notice there are no red bars - this is due to CLS not flagging anymore
![Screenshot 2021-03-15 at 13 03 23](https://user-images.githubusercontent.com/6905473/111158076-8732c100-858f-11eb-933f-c746237c3a5a.png)


I have also added an additional example under the `wrapAround` section examples so you can test these for yourselves.
I have personally tested how this work with: `wrapAround` and `rightToLeft` options - and these work fine but let me know if you think there are any more risks to these changes ^^


Would be good to get this merged soon-ish as this will probably affect a lot of sites' scores in May. 
Do let me know if we need any changes or if there's a good way to fix this for all occasions and not only for calculations done in `px`. 
