### PR TITLE
fix: use transform over left/right to eradicate CLS on 'wrap around'

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -41,6 +41,7 @@ proto.create = function() {
   this.element.setAttribute( 'aria-hidden', 'true' );
   this.x = 0;
   this.shift = 0;
+  this.element.style[ this.parent.originSide ] = 0;
 };
 
 proto.destroy = function() {
@@ -49,6 +50,7 @@ proto.destroy = function() {
   this.element.style.position = '';
   var side = this.parent.originSide;
   this.element.style[ side ] = '';
+  this.element.style.transform = '';
   this.element.removeAttribute('aria-hidden');
 };
 
@@ -71,8 +73,14 @@ proto.updateTarget = proto.setDefaultTarget = function() {
 
 proto.renderPosition = function( x ) {
   // render position of cell with in slider
-  var side = this.parent.originSide;
-  this.element.style[ side ] = this.parent.getPositionValue( x );
+  var sideOffset = this.parent.originSide === 'left' ? 1 : -1;
+
+  var adjustedX = this.parent.options.percentPosition ?
+    x * sideOffset * ( this.parent.size.innerWidth / this.size.width ) :
+    x * sideOffset;
+
+  this.element.style.transform = 'translateX(' +
+    this.parent.getPositionValue( adjustedX ) + ')';
 };
 
 proto.select = function() {


### PR DESCRIPTION
### Issue Description

Resolves https://github.com/metafizzy/flickity/issues/1087 (at least for the issue I am seeing; perhaps there are others).

Flickity instances using the `wrapAround` option are currently causing layout shift when 'wrapping'. [As noted on the issue](https://github.com/metafizzy/flickity/issues/1087#issuecomment-798593389), horizontal layout shift is being caused by manipulation of the `left` and `right` positioning values. May also be an issue for free scrolling carousels?

🚨 As also noted, action is required to resolve this issue to avoid all web pages using Flickity with `wrapAround: true`  being penalised for having a poor [Cumulative Layout Shift (CLS)](https://web.dev/cls/) field score. **[From May 2021, Google search ranking will be affected for all pages with poor 'Core Web Vitals'](https://developers.google.com/search/blog/2020/11/timing-for-page-experience) (of which CLS is one).**  🚨

### Resolution
Replace usage of `left`/`right` positioning with the correct `transform: translateX(value)` (which is CLS-friendly).

### Testing
Tested to have no CLS when using 'wrap around'. Couldn't find any regressions using the sandbox.

Functional testing and feedback from others would be very welcome here... or maybe others have a better solution? 🙂 