### PR TITLE
Accessibility Improvements

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -1,6 +1,3 @@
-
-
-
 // Flickity.Cell
 ( function( window, factory ) {
   // universal module definition

--- a/js/cell.js
+++ b/js/cell.js
@@ -1,3 +1,6 @@
+
+
+
 // Flickity.Cell
 ( function( window, factory ) {
   // universal module definition
@@ -83,13 +86,31 @@ proto.renderPosition = function( x ) {
     this.parent.getPositionValue( adjustedX ) + ')';
 };
 
+proto.showFocusables = function() {
+  console.log("running show",  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]'))
+  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
+    focusableEl.removeAttribute("aria-hidden")
+    focusableEl.setAttribute("tabindex", "0");
+  })
+};
+
 proto.select = function() {
   this.element.classList.add('is-selected');
+  this.showFocusables();
   this.element.removeAttribute('aria-hidden');
 };
 
+proto.hideFocusables = function() {
+  console.log("running hide",  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]'))
+  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
+    focusableEl.setAttribute("aria-hidden", "true");
+    focusableEl.setAttribute("tabindex", "-1");
+  });
+}
+
 proto.unselect = function() {
   this.element.classList.remove('is-selected');
+  this.hideFocusables(this.element);
   this.element.setAttribute( 'aria-hidden', 'true' );
 };
 

--- a/js/cell.js
+++ b/js/cell.js
@@ -41,7 +41,11 @@ var proto = Cell.prototype;
 
 proto.create = function() {
   this.element.style.position = 'absolute';
-  this.element.setAttribute( 'aria-hidden', 'true' );
+  this.element.setAttribute('aria-hidden', 'true');
+  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
+    focusableEl.setAttribute( 'aria-hidden', 'true' );
+    focusableEl.setAttribute("tabindex", "-1");
+  });
   this.x = 0;
   this.shift = 0;
   this.element.style[ this.parent.originSide ] = 0;
@@ -89,7 +93,7 @@ proto.renderPosition = function( x ) {
 proto.showFocusables = function() {
   console.log("running show",  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]'))
   this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
-    focusableEl.removeAttribute("aria-hidden")
+    focusableEl.removeAttribute("aria-hidden");
     focusableEl.setAttribute("tabindex", "0");
   })
 };
@@ -103,14 +107,14 @@ proto.select = function() {
 proto.hideFocusables = function() {
   console.log("running hide",  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]'))
   this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
-    focusableEl.setAttribute("aria-hidden", "true");
+    focusableEl.setAttribute( 'aria-hidden', 'true' );
     focusableEl.setAttribute("tabindex", "-1");
   });
 }
 
 proto.unselect = function() {
   this.element.classList.remove('is-selected');
-  this.hideFocusables(this.element);
+  this.hideFocusables();
   this.element.setAttribute( 'aria-hidden', 'true' );
 };
 

--- a/js/cell.js
+++ b/js/cell.js
@@ -27,6 +27,8 @@
 
 'use strict';
 
+var FOCUSABLES_SELECTOR = 'a[href], button, input, textarea, select, details,[tabindex]'
+
 function Cell( elem, parent ) {
   this.element = elem;
   this.parent = parent;
@@ -39,10 +41,7 @@ var proto = Cell.prototype;
 proto.create = function() {
   this.element.style.position = 'absolute';
   this.element.setAttribute('aria-hidden', 'true');
-  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
-    focusableEl.setAttribute( 'aria-hidden', 'true' );
-    focusableEl.setAttribute("tabindex", "-1");
-  });
+  _hideFocusables(this.element);
   this.x = 0;
   this.shift = 0;
   this.element.style[ this.parent.originSide ] = 0;
@@ -87,31 +86,29 @@ proto.renderPosition = function( x ) {
     this.parent.getPositionValue( adjustedX ) + ')';
 };
 
-proto.showFocusables = function() {
-  console.log("running show",  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]'))
-  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
-    focusableEl.removeAttribute("aria-hidden");
-    focusableEl.setAttribute("tabindex", "0");
+ function _showFocusables(element) {
+  element.querySelectorAll(FOCUSABLES_SELECTOR).forEach(focusableEl=>{
+    focusableEl.removeAttribute('aria-hidden');
+    focusableEl.setAttribute('tabindex', '0');
   })
 };
 
 proto.select = function() {
   this.element.classList.add('is-selected');
-  this.showFocusables();
+  _showFocusables(this.element);
   this.element.removeAttribute('aria-hidden');
 };
 
-proto.hideFocusables = function() {
-  console.log("running hide",  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]'))
-  this.element.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]').forEach(focusableEl=>{
-    focusableEl.setAttribute( 'aria-hidden', 'true' );
-    focusableEl.setAttribute("tabindex", "-1");
+ function _hideFocusables(element) {
+  element.querySelectorAll(FOCUSABLES_SELECTOR).forEach(focusableEl=>{
+    focusableEl.setAttribute('aria-hidden', 'true');
+    focusableEl.setAttribute('tabindex', '-1');
   });
 }
 
 proto.unselect = function() {
   this.element.classList.remove('is-selected');
-  this.hideFocusables();
+  _hideFocusables(this.element);
   this.element.setAttribute( 'aria-hidden', 'true' );
 };
 

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -190,6 +190,15 @@ proto.activate = function() {
     this.element.tabIndex = 0;
     // listen for key presses
     this.element.addEventListener( 'keydown', this );
+    // handle aria-live
+    if ( this.options.autoPlay ) {
+      // https://www.w3.org/TR/wai-aria-practices/examples/carousel/carousel-1.html
+      // Very importantly, if automatic rotation is turned on, the live region is disabled. If it were not, the page would be come unusable as announcements of the continuously changing content constantly interrupt anything else the user is reading.
+      this.element.setAttribute('aria-live', 'off')
+    } else {
+      // When automatic rotation is turned off, the carousel slide content is included in a live region. This makes it easier for screen reader users to scan through the carousel slides. When screen reader users activate the next or previous slide button , the new slide content is announced, giving users immediate feedback that helps them determine whether or not to interact with the content.
+      this.element.setAttribute('aria-live', 'assertive')
+    }
   }
 
   this.emitEvent('activate');

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -832,7 +832,7 @@ proto.watchCSS = function() {
 proto.onkeydown = function( event ) {
   // only work if element is in focus
   var isNotFocused = document.activeElement && document.activeElement != this.element;
-  if ( !this.options.accessibility || isNotFocused ) {
+  if ( !this.options.accessibility && isNotFocused ) {
     return;
   }
 

--- a/js/prev-next-button.js
+++ b/js/prev-next-button.js
@@ -58,7 +58,7 @@ PrevNextButton.prototype._create = function() {
   // init as disabled
   this.disable();
 
-  element.setAttribute( 'aria-label', this.isPrevious ? 'Previous' : 'Next' );
+  element.setAttribute( 'aria-label', this.isPrevious ? 'Previous Slide' : 'Next Slide' );
 
   // create arrow
   var svg = this.createSVG();


### PR DESCRIPTION
Hi @desandro 

In this PR I'm suggesting changes to address various accessibility concerns. 

* Address https://github.com/metafizzy/flickity/issues/776 by showing/hiding focusable elements inside a cell based on if the cell is selected.
* Set `aria-live` `assertive` to announce content as slides are changed, and handle related auto-play issues 
 https://github.com/metafizzy/flickity/issues/1041 and https://github.com/metafizzy/flickity/issues/1096
 * Make Prev/Next buttons more explicit
 * Allow arrow key navigation to continue even when focused on an element inside a slide.
 
 You can see an example here: https://5ef272f9ab690c0022ef30ab-chkmlbhrup.chromatic.com/?path=/story/carousel-carousel--carousel