### PR TITLE
add validation for image source

### DIFF
--- a/js/lazyload.js
+++ b/js/lazyload.js
@@ -89,7 +89,7 @@ LazyLoader.prototype.load = function() {
     this.img.getAttribute( lazySrcAttr );
   let srcset = this.img.getAttribute( lazySrcsetAttr );
   // set src & serset
-  this.img.src = src;
+  if ( src ) this.img.src = src;
   if ( srcset ) this.img.setAttribute( 'srcset', srcset );
   // remove attr
   this.img.removeAttribute( lazyAttr );


### PR DESCRIPTION
Check for src attribute being defined before setting it. This will help with `<source>` tags within `<picture>` tags to avoid the unnecessary src="null" on `<source>` tag that is required if the source element's parent is an `<audio>` and `<video>` element, but not allowed if the source element's parent is a `<picture> `element.

```html
<picture>
  <source type="..." data-flickity-lazyload-srcset="...">
  ...
<picture>
```

```html
<picture>
  <source type="..." srcset="..."  src="null">
<picture>
```
Based on [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)