### PR TITLE
Fix destroy event not firing

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -837,8 +837,8 @@ proto.deactivate = function() {
 proto.destroy = function() {
   this.deactivate();
   window.removeEventListener( 'resize', this );
-  this.allOff();
   this.emitEvent('destroy');
+  this.allOff();
   if ( jQuery && this.$element ) {
     jQuery.removeData( this.element, 'flickity' );
   }

--- a/test/unit/destroy.js
+++ b/test/unit/destroy.js
@@ -2,12 +2,18 @@ QUnit.test( 'destroy', function( assert ) {
 
   let elem = document.querySelector('#destroy');
   let flkty = new Flickity( elem );
+  let destroyFired = false;
+
+  flkty.on( 'destroy', () => {
+    destroyFired = true;
+  } );
 
   let done = assert.async();
   // do it async
   setTimeout( function() {
     flkty.destroy();
     assert.strictEqual( elem.flickityGUID, undefined, 'flickityGUID removed' );
+    assert.ok( destroyFired, 'destroy event fired' );
     assert.ok( !flkty.isActive, 'not active' );
     assert.ok( !Flickity.data( elem ), '.data() returns falsey' );
     assert.ok( elem.children[0], '.cell', 'cell is back as first child' );


### PR DESCRIPTION
The `destroy` event was effectively not firing due to [`allOff` being called and removing any `destroy` listeners](https://github.com/metafizzy/flickity/blob/a64cc33052150417bb84c724b937097308519d6e/js/core.js#L840) before the event was emitted.

This change fixes that issue and introduces an assertion for the event being fired.